### PR TITLE
Fix overlapping of #giantfox on #operators section

### DIFF
--- a/media/css/firefox/partners/desktop.less
+++ b/media/css/firefox/partners/desktop.less
@@ -183,8 +183,10 @@ h2 {
     height: 700px;
     background: url(/media/img/firefox/partners/firefoxos-giantfox-back.png) no-repeat 0 0 ;
     position: absolute;
+    z-index: 40;
     top: 140px;
-    left: 45%;
+    left: 50%;
+    margin-left: -70px;
     .transition(all ease 0.6s);
     #giantfox-foreground {
         position: absolute;
@@ -265,6 +267,7 @@ h2 {
 
 #os {
     .intro {
+        z-index: 50;
         padding-top: 140px;
         .span(7);
         .narrow {

--- a/media/js/firefox/partners/desktop.js
+++ b/media/js/firefox/partners/desktop.js
@@ -51,7 +51,7 @@
             // reset phone & giantfox
             $phone.animate({ 'left': '50%' }, phone_speed);
             $phone_android.animate({ 'left': '50%' }, phone_speed);
-            $giantfox.css('left', '45%');
+            $giantfox.css('margin-left', '-70px');
 
             // force all first sections to be current
             $('.partner-article').each(function(i, article) {
@@ -150,11 +150,11 @@
         });
 
         $('a[data-section="os-operators"]').on('click', function() {
-            $giantfox.css('left', '-45%');
+            $giantfox.css('margin-left', '-1380px');
         });
 
         $('a[data-section="os-overview"]').on('click', function() {
-            $giantfox.css('left', '45%');
+            $giantfox.css('margin-left', '-70px');
         });
 
         var _move_phone = function(factor, slide, new_z) {


### PR DESCRIPTION
The #giantfox div is now always positioned left:50% and the moving is done with margin-left rather than left. This keeps the fox in sync with the page content, rather than the viewport width
